### PR TITLE
Add Grapevine Petiole Dehydration datasets

### DIFF
--- a/docs/source/data/docs.data.petioles.rst
+++ b/docs/source/data/docs.data.petioles.rst
@@ -32,7 +32,7 @@ The datasets were acquired at the Advanced Light Source (ALS) beamline 8.3.2 in 
 
 The dataset includes 14 raw tomographic scans divided into two dynamic dehydration sequences, along with a unified archive of high-quality expert-curated segmentation masks:
 
-*   **Expert-curated Masks**: :download:`annotations.tar.zst <https://zenodo.org/records/19476729/files/annotations.tar.zst>` - Semantic instances for 42 cross-sections (background, cortex, phloem fibers, phloem, hydrated xylem, air-filled pith, water-filled pith, dehydrated xylem, and ignore regions).
+*   **Expert-curated Masks**: :download:`annotations.tar.zst <https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fannotations.tar.zst>` - Semantic instances for 42 cross-sections (background, cortex, phloem fibers, phloem, hydrated xylem, air-filled pith, water-filled pith, dehydrated xylem, and ignore regions).
 *   **Time Series 1**: 6 sequential scans of a single grapevine petiole undergoing dehydration (Petioles 22-27).
 *   **Time Series 2**: 8 sequential scans of a second grapevine petiole undergoing dehydration (Petioles 33-40).
 
@@ -44,49 +44,63 @@ To load the datasets and perform a basic reconstruction using `tomopy <https://t
     :width: 20pt
     :height: 20pt
 
-+-----------------------+----------+-------------------------------------------------+----------------+
-| Tomo ID               | Sequence | Sample / Filename                               | Image Preview  |
-+=======================+==========+=================================================+================+
-| petiole_22_           | TS1      | 20260221_135217_petiole22.h5                    | |grapevine|    |
-+-----------------------+----------+-------------------------------------------------+----------------+
-| petiole_23_           | TS1      | 20260221_140347_petiole23.h5                    | |grapevine|    |
-+-----------------------+----------+-------------------------------------------------+----------------+
-| petiole_24_           | TS1      | 20260221_140816_petiole24.h5                    | |grapevine|    |
-+-----------------------+----------+-------------------------------------------------+----------------+
-| petiole_25_           | TS1      | 20260221_141434_petiole25.h5                    | |grapevine|    |
-+-----------------------+----------+-------------------------------------------------+----------------+
-| petiole_26_           | TS1      | 20260221_141945_petiole26.h5                    | |grapevine|    |
-+-----------------------+----------+-------------------------------------------------+----------------+
-| petiole_27_           | TS1      | 20260221_142453_petiole27.h5                    | |grapevine|    |
-+-----------------------+----------+-------------------------------------------------+----------------+
-| petiole_33_           | TS2      | 20260221_154210_petiole33.h5                    | |grapevine|    |
-+-----------------------+----------+-------------------------------------------------+----------------+
-| petiole_34_           | TS2      | 20260221_154714_petiole34.h5                    | |grapevine|    |
-+-----------------------+----------+-------------------------------------------------+----------------+
-| petiole_35_           | TS2      | 20260221_155149_petiole35.h5                    | |grapevine|    |
-+-----------------------+----------+-------------------------------------------------+----------------+
-| petiole_36_           | TS2      | 20260221_155821_petiole36.h5                    | |grapevine|    |
-+-----------------------+----------+-------------------------------------------------+----------------+
-| petiole_37_           | TS2      | 20260221_160336_petiole37.h5                    | |grapevine|    |
-+-----------------------+----------+-------------------------------------------------+----------------+
-| petiole_38_           | TS2      | 20260221_160807_petiole38.h5                    | |grapevine|    |
-+-----------------------+----------+-------------------------------------------------+----------------+
-| petiole_39_           | TS2      | 20260221_161542_petiole39.h5                    | |grapevine|    |
-+-----------------------+----------+-------------------------------------------------+----------------+
-| petiole_40_           | TS2      | 20260221_162040_petiole40.h5                    | |grapevine|    |
-+-----------------------+----------+-------------------------------------------------+----------------+
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
+| Tomo ID               | Sequence | Sample / Filename                               | Image Preview  | Reconstruction   |
++=======================+==========+=================================================+================+==================+
+| petiole_22_           | TS1      | 20260221_135217_petiole22.h5                    | |grapevine|    | rec_22_          |
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
+| petiole_23_           | TS1      | 20260221_140347_petiole23.h5                    | |grapevine|    | rec_23_          |
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
+| petiole_24_           | TS1      | 20260221_140816_petiole24.h5                    | |grapevine|    | rec_24_          |
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
+| petiole_25_           | TS1      | 20260221_141434_petiole25.h5                    | |grapevine|    | rec_25_          |
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
+| petiole_26_           | TS1      | 20260221_141945_petiole26.h5                    | |grapevine|    | rec_26_          |
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
+| petiole_27_           | TS1      | 20260221_142453_petiole27.h5                    | |grapevine|    | rec_27_          |
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
+| petiole_33_           | TS2      | 20260221_154210_petiole33.h5                    | |grapevine|    | rec_33_          |
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
+| petiole_34_           | TS2      | 20260221_154714_petiole34.h5                    | |grapevine|    | rec_34_          |
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
+| petiole_35_           | TS2      | 20260221_155149_petiole35.h5                    | |grapevine|    | rec_35_          |
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
+| petiole_36_           | TS2      | 20260221_155821_petiole36.h5                    | |grapevine|    | rec_36_          |
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
+| petiole_37_           | TS2      | 20260221_160336_petiole37.h5                    | |grapevine|    | rec_37_          |
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
+| petiole_38_           | TS2      | 20260221_160807_petiole38.h5                    | |grapevine|    | rec_38_          |
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
+| petiole_39_           | TS2      | 20260221_161542_petiole39.h5                    | |grapevine|    | rec_39_          |
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
+| petiole_40_           | TS2      | 20260221_162040_petiole40.h5                    | |grapevine|    | rec_40_          |
++-----------------------+----------+-------------------------------------------------+----------------+------------------+
 
-.. _petiole_22: https://zenodo.org/records/19476729/files/petiole22_raw_rec.tar.zst
-.. _petiole_23: https://zenodo.org/records/19476729/files/petiole23_raw_rec.tar.zst
-.. _petiole_24: https://zenodo.org/records/19476729/files/petiole24_raw_rec.tar.zst
-.. _petiole_25: https://zenodo.org/records/19476729/files/petiole25_raw_rec.tar.zst
-.. _petiole_26: https://zenodo.org/records/19476729/files/petiole26_raw_rec.tar.zst
-.. _petiole_27: https://zenodo.org/records/19476729/files/petiole27_raw_rec.tar.zst
-.. _petiole_33: https://zenodo.org/records/19476729/files/petiole33_raw_rec.tar.zst
-.. _petiole_34: https://zenodo.org/records/19476729/files/petiole34_raw_rec.tar.zst
-.. _petiole_35: https://zenodo.org/records/19476729/files/petiole35_raw_rec.tar.zst
-.. _petiole_36: https://zenodo.org/records/19476729/files/petiole36_raw_rec.tar.zst
-.. _petiole_37: https://zenodo.org/records/19476729/files/petiole37_raw_rec.tar.zst
-.. _petiole_38: https://zenodo.org/records/19476729/files/petiole38_raw_rec.tar.zst
-.. _petiole_39: https://zenodo.org/records/19476729/files/petiole39_raw_rec.tar.zst
-.. _petiole_40: https://zenodo.org/records/19476729/files/petiole40_raw_rec.tar.zst
+.. _petiole_22: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fraw%2F20260221_135217_petiole22.h5
+.. _petiole_23: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fraw%2F20260221_140347_petiole23.h5
+.. _petiole_24: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fraw%2F20260221_140816_petiole24.h5
+.. _petiole_25: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fraw%2F20260221_141434_petiole25.h5
+.. _petiole_26: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fraw%2F20260221_141945_petiole26.h5
+.. _petiole_27: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fraw%2F20260221_142453_petiole27.h5
+.. _petiole_33: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fraw%2F20260221_154210_petiole33.h5
+.. _petiole_34: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fraw%2F20260221_154714_petiole34.h5
+.. _petiole_35: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fraw%2F20260221_155149_petiole35.h5
+.. _petiole_36: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fraw%2F20260221_155821_petiole36.h5
+.. _petiole_37: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fraw%2F20260221_160336_petiole37.h5
+.. _petiole_38: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fraw%2F20260221_160807_petiole38.h5
+.. _petiole_39: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fraw%2F20260221_161542_petiole39.h5
+.. _petiole_40: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Fraw%2F20260221_162040_petiole40.h5
+.. _rec_22: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Freconstruction%2Fpetiole22%2F
+.. _rec_23: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Freconstruction%2Fpetiole23%2F
+.. _rec_24: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Freconstruction%2Fpetiole24%2F
+.. _rec_25: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Freconstruction%2Fpetiole25%2F
+.. _rec_26: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Freconstruction%2Fpetiole26%2F
+.. _rec_27: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Freconstruction%2Fpetiole27%2F
+.. _rec_33: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Freconstruction%2Fpetiole33%2F
+.. _rec_34: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Freconstruction%2Fpetiole34%2F
+.. _rec_35: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Freconstruction%2Fpetiole35%2F
+.. _rec_36: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Freconstruction%2Fpetiole36%2F
+.. _rec_37: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Freconstruction%2Fpetiole37%2F
+.. _rec_38: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Freconstruction%2Fpetiole38%2F
+.. _rec_39: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Freconstruction%2Fpetiole39%2F
+.. _rec_40: https://app.globus.org/file-manager?destination_id=472d6c6f-dc53-420f-9a12-b3515282f1c1&destination_path=%2Ftomobank_petioles%2Freconstruction%2Fpetiole40%2F


### PR DESCRIPTION
This Pull Request registers the newly released Grapevine Petiole Dehydration time-series datasets in TomoBank. Links to the datasets point to the Globus endpoint containing the raw projections and reconstructions.